### PR TITLE
Add recommendationt to mark new template versions as "stable".

### DIFF
--- a/docs/continuous-delivery/cd-onboarding/new-user/rampup-templates.md
+++ b/docs/continuous-delivery/cd-onboarding/new-user/rampup-templates.md
@@ -258,9 +258,9 @@ Once everything is done and checks out good, merge the feature branch to main, w
 
 ### Releasing Template Updates
 
-When following the above flow, template updates for non breaking changes are released out to users automatically with no intervention once the update is merged.  
+When following the above flow, template updates for non breaking changes are released out to users automatically with no intervention once the update is merged.
 
-For breaking changes, users should be notified when the new version becomes available so they can update their pipelines to consume the new version. An end of life date should be set for the old version, by which all template consumers should complete moving over to the new version. Pipelines in scope can be determined by using the "Referenced By" tab when viewing the template in the templates menu.
+For breaking changes, when the new Template version is complete the branch should be merged down to `main` and marked as "stable" in the template studio. Then users of the template should be notified that the new version is available and update their pipelines to consume the new version. Pipelines in scope can be determined by using the "Referenced By" tab when viewing the template in the templates menu.  An end of life date should be set for the old version, by which all template consumers should complete moving over to the new version.
 
 Template consumers incorporating new versions containing breaking changes should make their updates on a feature branch, to avoid impacting their users.  Like templates, this is accomplished by using the GitX feature to remotely track the pipeline or template in a git repository.  Saving the changes to a new feature branch, and selecting this branch when running the pipeline to test the change.  Once the changes are tested with a successful pipeline run, merge the feature branch into `main` to roll the change out to the production pipeline.
 


### PR DESCRIPTION
Thanks for contributing to the Harness Developer Hub! Our code owners will review your submission.

## Description

* Please describe your changes: This updates the templates best practices guide to add a recommendation for marking new template versions as stable.  This is needed so this new version is used by default in new pipelines.
* Jira/GitHub Issue numbers (if any): None
* Preview links/images (Internal contributors only): \__________________

## PR lifecycle

We aim to merge PRs within one week or less, but delays happen sometimes.

If your PR is open longer than two weeks without any human activity, please tag a [code owner](https://github.com/harness/developer-hub/blob/main/.github/CODEOWNERS) in a comment.

PRs must meet these requirements to be merged:

- [ ] Successful preview build.
- [ ] Code owner review.
- [ ] No merge conflicts.
- [ ] Release notes/new features docs: Feature/version released to at least one prod environment.
